### PR TITLE
style: fix grammar error in browser capture log message

### DIFF
--- a/docs/config/01-configuration-file.md
+++ b/docs/config/01-configuration-file.md
@@ -853,11 +853,11 @@ When running a browser in different environments, it can take different amounts 
 client socket to connect. If Karma cannot connect within the default timeout, you may see an
 error similar to the following:
 ```
-ChromeHeadless have not captured in 60000ms, killing.
+ChromeHeadless has not captured in 60000ms, killing.
 Trying to start ChromeHeadless again (1/2).
-ChromeHeadless have not captured in 60000ms, killing.
+ChromeHeadless has not captured in 60000ms, killing.
 Trying to start ChromeHeadless again (2/2).
-ChromeHeadless have not captured in 60000ms, killing.
+ChromeHeadless has not captured in 60000ms, killing.
 ChromeHeadless failed 2 times(timeout). Giving up.
 ```
 If you see this error, you can try increasing the socket connection timeout.

--- a/lib/launchers/capture_timeout.js
+++ b/lib/launchers/capture_timeout.js
@@ -17,7 +17,7 @@ function CaptureTimeoutLauncher (timer, captureTimeout) {
         return
       }
 
-      log.warn(`${this.name} have not captured in ${captureTimeout} ms, killing.`)
+      log.warn(`${this.name} has not captured in ${captureTimeout} ms, killing.`)
       this.error = 'timeout'
       this.kill()
     }, captureTimeout)

--- a/test/e2e/timeout.feature
+++ b/test/e2e/timeout.feature
@@ -17,5 +17,5 @@ Feature: Timeout
     When I start Karma
     Then it fails with like:
       """
-      have not captured in 100 ms
+      has not captured in 100 ms
       """


### PR DESCRIPTION
Fixes a grammar error in the log message when a browser does not capture in time.

Fixes #3716